### PR TITLE
Adjust rem units after removing global font-size

### DIFF
--- a/src/app/Atoms/Button/Button.module.scss
+++ b/src/app/Atoms/Button/Button.module.scss
@@ -4,12 +4,12 @@
 .button {
 	border: none;
 	border-radius: variables.$radius-lg;
-	padding: 1.6rem 3.2rem;
+	padding: 1.0rem 2.0rem;
 	cursor: pointer;
 	transition: background-color 0.2s ease, color 0.2s ease;
 
 	&:focus-visible {
-		outline-offset: 0.2rem;
+		outline-offset: 0.1rem;
 	}
 }
 
@@ -22,7 +22,7 @@
 	}
 
 	&:focus-visible {
-		outline: 0.2rem solid var(--color-primary);
+		outline: 0.1rem solid var(--color-primary);
 	}
 }
 
@@ -35,6 +35,6 @@
 	}
 
 	&:focus-visible {
-		outline: 0.2rem solid var(--color-primary);
+		outline: 0.1rem solid var(--color-primary);
 	}
 }

--- a/src/app/Atoms/Checkbox/Checkbox.module.scss
+++ b/src/app/Atoms/Checkbox/Checkbox.module.scss
@@ -5,7 +5,7 @@
 .checkbox {
 	display: flex;
 	align-items: flex-start;
-	gap: 1.6rem;
+	gap: 1.0rem;
 	cursor: pointer;
 
 	input {
@@ -20,14 +20,14 @@
 	}
 
 	&:focus-within .checkmark {
-		outline: 0.2rem solid var(--color-primary);
-		outline-offset: 0.2rem;
+		outline: 0.1rem solid var(--color-primary);
+		outline-offset: 0.1rem;
 	}
 
 	.checkmark {
 		display: inline-block;
-		width: 2.4rem;
-		height: 2.4rem;
+		width: 1.5rem;
+		height: 1.5rem;
 		border: 0.1rem solid black;
 		border-radius: variables.$radius-md;
 		position: relative;
@@ -41,12 +41,12 @@
 	input:checked + .checkmark::after {
 		content: "";
 		position: absolute;
-		left: 0.85rem;
-		top: 0.45rem;
-		width: 0.5rem;
-		height: 1rem;
+		left: 0.5rem;
+		top: 0.3rem;
+		width: 0.3rem;
+		height: 0.6rem;
 		border: solid white;
-		border-width: 0 0.2rem 0.2rem 0;
+		border-width: 0 0.1rem 0.1rem 0;
 		transform: rotate(45deg);
 	}
 

--- a/src/app/Atoms/InputField/InputField.module.scss
+++ b/src/app/Atoms/InputField/InputField.module.scss
@@ -9,7 +9,7 @@
 	width: 100%;
 
 	&:focus-visible {
-		outline: 0.2rem solid var(--color-primary);
+		outline: 0.1rem solid var(--color-primary);
 	}
 
 	&::placeholder {

--- a/src/app/Atoms/SmartEditor/SmartEditor.module.scss
+++ b/src/app/Atoms/SmartEditor/SmartEditor.module.scss
@@ -3,7 +3,7 @@
 
 .smart-editor {
 	@include typography.text-base;
-	min-height: 20rem;
+	min-height: 12.5rem;
 	resize: vertical;
 	padding: var(--space-md);
 	margin: var(--space-md);
@@ -11,7 +11,7 @@
 	border-radius: variables.$radius-md;
 
 	&:focus-visible {
-		outline: .2rem solid var(--color-primary);
+		outline: 0.1rem solid var(--color-primary);
 	}
 
 	&::placeholder {

--- a/src/app/Atoms/SmartTextarea/SmartTextarea.module.scss
+++ b/src/app/Atoms/SmartTextarea/SmartTextarea.module.scss
@@ -4,7 +4,7 @@
 
 .smart-textarea {
 	@include typography.text-base;
-	min-height: 20rem;
+	min-height: 12.5rem;
 	resize: vertical;
 	padding: var(--space-md);
 	margin: var(--space-md);
@@ -12,7 +12,7 @@
 	border-radius: variables.$radius-md;
 
 	&:focus-visible {
-		outline: .2rem solid var(--color-primary);
+		outline: 0.1rem solid var(--color-primary);
 	}
 
 	&::placeholder {

--- a/src/app/Components/AddTaskModal/AddTaskModal.module.scss
+++ b/src/app/Components/AddTaskModal/AddTaskModal.module.scss
@@ -4,10 +4,10 @@
 .add-task-button {
 	@include mixins.background-shadow;
 	position: fixed;
-	right: 2.4rem;
-	bottom: 2.4rem;
-	width: 5.6rem;
-	height: 5.6rem;
+	right: 1.5rem;
+	bottom: 1.5rem;
+	width: 3.5rem;
+	height: 3.5rem;
 	border-radius: variables.$radius-rounded;
 	background-color: var(--color-primary);
 	color: white;
@@ -20,8 +20,8 @@
 	}
 
 	&:focus-visible {
-		outline: .2rem solid var(--color-primary);
-		outline-offset: .2rem;
+		outline: 0.1rem solid var(--color-primary);
+		outline-offset: 0.1rem;
 	}
 }
 
@@ -44,7 +44,7 @@
 	left: 0;
 	width: 100%;
 	background-color: white;
-	padding: 2.5rem;
+	padding: 1.6rem;
 	border-radius: 0 0 variables.$radius-lg variables.$radius-lg;
 	z-index: 1000;
 	animation-duration: 1000ms;
@@ -63,8 +63,8 @@
 	}
 
 	.Description {
-		margin: 1rem 0 2rem;
-		font-size: 1.5rem;
+		margin: 0.6rem 0 1.3rem;
+		font-size: 0.9rem;
 		color: #444;
 		line-height: 1.5;
 	}
@@ -73,9 +73,9 @@
 	.fieldset {
 		border: none;
 		display: flex;
-		gap: 2rem;
+		gap: 1.3rem;
 		align-items: center;
-		margin-bottom: 1.5rem;
+		margin-bottom: 0.9rem;
 	}
 
 	.button-group {

--- a/src/app/Components/DailyTextareaBlock/DailyTextareaBlock.module.scss
+++ b/src/app/Components/DailyTextareaBlock/DailyTextareaBlock.module.scss
@@ -7,12 +7,12 @@
 	flex-direction: column;
 	background-color: white;
 	border-radius: variables.$radius-lg;
-	border: .1rem solid var(--color-border);
+	border: 0.1rem solid var(--color-border);
 
 	.date {
 		@include typography.text-base;
 		display: flex;
-		border-bottom: .1rem solid var(--color-border);
+		border-bottom: 0.1rem solid var(--color-border);
 		padding: var(--space-md);
 		gap: var(--space-sm);
 		align-items: center;
@@ -20,8 +20,8 @@
 
 	.day-batch {
 		color: var(--color-primary);
-		padding-inline: .8rem;
-		padding-block: .4rem;
+		padding-inline: 0.5rem;
+		padding-block: 0.3rem;
 		border-radius: variables.$radius-md;
 		background-color: var(--color-primary-light);
 	}
@@ -32,15 +32,15 @@
 
 	.textarea {
 		@include typography.text-base;
-		min-height: 20rem;
+		min-height: 12.5rem;
 		resize: vertical;
 		padding: var(--space-md);
 		margin: var(--space-md);
 		border: 1px solid #ccc;
-		border-radius: 0.5rem;
+		border-radius: 0.3rem;
 
 		&:focus-visible {
-			outline: .2rem solid var(--color-primary);
+			outline: 0.1rem solid var(--color-primary);
 		}
 
 		&::placeholder {
@@ -50,7 +50,7 @@
 
 	@include mixins.tablet {
 		.textarea {
-			min-height: 40rem;
+			min-height: 25.0rem;
 		}
 	}
 }

--- a/src/app/Components/DesktopNavigation/DesktopNavigation.module.scss
+++ b/src/app/Components/DesktopNavigation/DesktopNavigation.module.scss
@@ -5,14 +5,14 @@
 .desktop-navigation {
 	display: flex;
 	align-items: center;
-	border-bottom: .1rem solid var(--color-border);
+	border-bottom: 0.1rem solid var(--color-border);
 	background-color: white;
 	height: variables.$desktop-navi-height;
 
 	.logo-section {
 		padding: var(--space-lg);
-		border-right: .1rem solid var(--color-border);
-		max-width: 40rem;
+		border-right: 0.1rem solid var(--color-border);
+		max-width: 25.0rem;
 		width: 30dvw;
 	}
 

--- a/src/app/Components/MobileNavigation/MobileNavigation.module.scss
+++ b/src/app/Components/MobileNavigation/MobileNavigation.module.scss
@@ -17,7 +17,7 @@
 		position: relative;
 		display: flex;
 		justify-content: space-between;
-		border-bottom: .1rem solid var(--color-border);
+		border-bottom: 0.1rem solid var(--color-border);
 		padding-block: var(--space-md);
 		padding-inline: var(--content-spacing);
 	}
@@ -35,12 +35,12 @@
 
 		&:focus-visible {
 			color: var(--color-primary);
-			outline: .2rem solid var(--color-primary);
+			outline: 0.1rem solid var(--color-primary);
 			border-radius: variables.$radius-sm;
 		}
 
 		.slider-button-label {
-			padding: .2rem .4rem;
+			padding: 0.1rem 0.3rem;
 		}
 	}
 
@@ -59,7 +59,7 @@
 	.date-section {
 		padding-block: var(--space-xl);
 		padding-inline: var(--content-spacing);
-		border-bottom: .1rem solid var(--color-border);
+		border-bottom: 0.1rem solid var(--color-border);
 	}
 
 	.calendar-section {
@@ -82,16 +82,16 @@
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		height: 7rem;
-		min-width: 8rem;
-		width: 6rem;
+		height: 4.4rem;
+		min-width: 5.0rem;
+		width: 3.8rem;
 		border-radius: variables.$radius-md;
 		color: var(--color-text-muted);
 		cursor: pointer;
 		scroll-snap-align: center;
 
 		&:focus-visible {
-			outline: .2rem solid var(--color-primary);
+			outline: 0.1rem solid var(--color-primary);
 		}
 
 		&:hover {

--- a/src/app/Components/SideBar/Sidebar.module.scss
+++ b/src/app/Components/SideBar/Sidebar.module.scss
@@ -8,34 +8,34 @@
 	flex-direction: column;
 	justify-content: space-between;
 	background-color: white;
-	max-width: 40rem;
+	max-width: 25.0rem;
 	width: 30dvw;
-	border-right: .1rem solid var(--color-border);
+	border-right: 0.1rem solid var(--color-border);
 	//overflow: hidden;
 
 	.profile-section {
 		display: flex;
-		border-bottom: .1rem solid var(--color-border);
+		border-bottom: 0.1rem solid var(--color-border);
 		padding: var(--space-lg);
 		gap: var(--space-md);
 	}
 
 	.profile-button {
-		height: 4.5rem;
-		width: 4.5rem;
+		height: 2.8rem;
+		width: 2.8rem;
 		border-radius: variables.$radius-rounded;
 		border: none;
 		cursor: pointer;
 
 		&:focus-visible {
-			outline: .2rem solid var(--color-primary);
-			outline-offset: .2rem;
+			outline: 0.1rem solid var(--color-primary);
+			outline-offset: 0.1rem;
 		}
 	}
 
 	.profile-image {
-		height: 4.5rem;
-		width: 4.5rem;
+		height: 2.8rem;
+		width: 2.8rem;
 		object-fit: cover;
 		border-radius: variables.$radius-rounded;
 	}
@@ -62,7 +62,7 @@
 
 	.week-slider-section {
 		padding: var(--space-lg);
-		border-bottom: .1rem solid var(--color-border);
+		border-bottom: 0.1rem solid var(--color-border);
 
 	}
 
@@ -81,7 +81,7 @@
 		position: sticky;
 		top:0;
 		padding-block: var(--space-lg);
-		border-bottom: .1rem solid var(--color-border);
+		border-bottom: 0.1rem solid var(--color-border);
 	}
 
 	.remember-header {
@@ -105,16 +105,16 @@
 		border: none;
 		display: flex;
 		cursor: pointer;
-		gap: .4rem;
+		gap: 0.3rem;
 		justify-content: center;
-		padding-right: .5rem;
-		padding-block: .3rem;
+		padding-right: 0.3rem;
+		padding-block: 0.2rem;
 		margin-inline: var(--space-lg);;
 
 		&:focus-visible {
 			border-radius: variables.$radius-sm;
-			outline: .2rem solid var(--color-primary);
-			outline-offset: .2rem;
+			outline: 0.1rem solid var(--color-primary);
+			outline-offset: 0.1rem;
 		}
 	}
 
@@ -134,8 +134,8 @@
 		background-color: white;
 		border: none;
 		cursor: pointer;
-		padding-block: .3rem;
-		padding-inline: .5rem;
+		padding-block: 0.2rem;
+		padding-inline: 0.3rem;
 		color: var(--color-text-settings);
 
 		&:hover {
@@ -144,7 +144,7 @@
 
 		&:focus-visible {
 			color: var(--color-text);;
-			outline: .2rem solid var(--color-text);;
+			outline: 0.1rem solid var(--color-text);;
 			border-radius: variables.$radius-sm;
 		}
 	}

--- a/src/app/Components/TaskItem/TaskItem.module.scss
+++ b/src/app/Components/TaskItem/TaskItem.module.scss
@@ -8,7 +8,7 @@
 	padding-block: var(--space-xl);
 	border-radius: variables.$radius-md;
 	background: white;
-	box-shadow: 0 .1rem .2rem 0 rgba(0, 0, 0, 0.05);
+	box-shadow: 0 0.1rem 0.1rem 0 rgba(0, 0, 0, 0.05);
 	justify-content: space-between;
 	gap: var(--space-xl);
 
@@ -24,8 +24,8 @@
 		}
 
 		&:focus-visible {
-			outline: .2rem solid var(--color-primary);
-			outline-offset: .3rem;
+			outline: 0.1rem solid var(--color-primary);
+			outline-offset: 0.2rem;
 			border-radius: variables.$radius-sm;
 		}
 	}

--- a/src/app/Components/WeeklySlider/WeeklySlider.module.scss
+++ b/src/app/Components/WeeklySlider/WeeklySlider.module.scss
@@ -20,7 +20,7 @@
 
 	&:focus-visible {
 		color: var(--color-primary);
-		outline: .2rem solid var(--color-primary);
-		outline-offset: .4rem;
+		outline: 0.1rem solid var(--color-primary);
+		outline-offset: 0.3rem;
 	}
 }

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -62,7 +62,7 @@
 }
 
 html {
-	font-size: 62.5%;
+	/* font-size: 62.5%; - Removed to use browser default (16px = 1rem) */
 }
 
 *,

--- a/src/app/styles/_typography.scss
+++ b/src/app/styles/_typography.scss
@@ -44,31 +44,31 @@
 }
 
 @mixin text-xl {
-	font-size: 2rem;
+	font-size: 1.3rem;
 	font-weight: 600;
 	line-height: 1.4;
 }
 
 @mixin text-lg {
-	font-size: 1.8rem;
+	font-size: 1.1rem;
 	font-weight: 500;
 	line-height: 1.5;
 }
 
 @mixin text-base {
-	font-size: 1.6rem;
+	font-size: 1.0rem;
 	font-weight: 500;
 	line-height: 1.6;
 }
 
 @mixin text-sm {
-	font-size: 1.4rem;
+	font-size: 0.9rem;
 	font-weight: 500;
 	line-height: 1.6;
 }
 
 @mixin text-xs {
-	font-size: 1.2rem;
+	font-size: 0.8rem;
 	font-weight: 500;
 	line-height: 1.4;
 }

--- a/src/app/styles/_variables.scss
+++ b/src/app/styles/_variables.scss
@@ -13,10 +13,10 @@ $color-gray-light: #f9fafb;
 $color-day-label: #f3f4f6;
 
 // border radius
-$radius-sm: 0.4rem;
-$radius-md: 0.6rem;
-$radius-lg: 1.2rem;
+$radius-sm: 0.3rem;
+$radius-md: 0.4rem;
+$radius-lg: 0.8rem;
 $radius-rounded: 50%;
 
 //desktop navigation height
-$desktop-navi-height: 8rem;
+$desktop-navi-height: 5.0rem;


### PR DESCRIPTION
Remove `font-size: 62.5%` from `globals.scss` and adjust all `rem` values to maintain visual consistency.

The `font-size: 62.5%` rule previously set `1rem` to `10px`. By removing it, `1rem` now defaults to `16px`. All existing `rem` values were multiplied by `0.625` (10/16) and rounded to one decimal place to ensure the UI's visual size remains unchanged.

---
<a href="https://cursor.com/background-agent?bcId=bc-75eab392-44b4-48c6-b70d-289586278052">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75eab392-44b4-48c6-b70d-289586278052">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>